### PR TITLE
[Feat] 파일 확장자 인터셉터 추가

### DIFF
--- a/src/main/java/flow/assignment/common/FileSignature.java
+++ b/src/main/java/flow/assignment/common/FileSignature.java
@@ -1,0 +1,43 @@
+package flow.assignment.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FileSignature {
+    PNG_SIGNATURE("png", "89504e47"),
+    JPG_SIGNATURE("jpg", "ffd8ffe0"),
+    JPEG_SIGNATURE("jpeg", "ffd8ffe0"),
+    BAT_SIGNATURE("bat", "5B332f31"),
+    MP4_SIGNATURE("mp4", "00000018"),
+    IMG_SIGNATURE("img", "00010008"),
+    PPT_SIGNATURE("ppt", "006e1ef0"),
+    DOC_SIGNATURE("doc", "0d444d43"),
+    PDF_SIGNATURE("pdf", "25504446"),
+    GIF_SIGNATURE("gif", "47494638"),
+    MP3_SIGNATURE("mp3", "494433"),
+    JAR_SIGNATURE("jar", "4a415243"),
+    EXE_SIGNATURE("exe", "4d5a"),
+    ZIP_SIGNATURE("zip", "054B0304"),
+    DOCX_SIGNATURE("docx", "504B0304"),
+    TAR_SIGNATURE("tar", "75737461"),
+    ;
+
+    private String extension;
+    private String fileSignature;
+
+    public static Boolean isEqualsSignature(String extension, String signature) {
+        for (FileSignature fileSignature : FileSignature.values()) {
+            if (fileSignature.getExtension().equals(extension)) {
+                if (fileSignature.getFileSignature().equals(signature)) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/flow/assignment/common/MimeType.java
+++ b/src/main/java/flow/assignment/common/MimeType.java
@@ -1,0 +1,46 @@
+package flow.assignment.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum MimeType {
+    AUDIO_AAC("audio/aac", "aac"),
+    APPLICATION_X_ABIWORD("application/x-abiword", "abw"),
+    APPLICATION_X_FREEARC("application/x-freearc", "arc"),
+    IMAGE_AVIF("image/avif", "avif"),
+    VIDEO_X_MSVIDEO("video/x-msvideo", "avi"),
+    APPLICATION_VND_AMAZON_EBOOK("application/vnd.amazon.ebook", "azw"),
+    APPLICATION_OCTET_STREAM("application/octet-stream", "bin"),
+    IMAGE_BMP("image/bmp", "bmp"),
+    APPLICATION_X_BZIP("application/x-bzip", "bz"),
+    APPLICATION_X_BZIP2("application/x-bzip2", "bz2"),
+    APPLICATION_X_CDF("application/x-cdf", "cda"),
+    APPLICATION_X_CSH("application/x-csh", "csh"),
+    TEXT_CSS("text/css", "css"),
+    TEXT_CSV("text/csv", "csv"),
+    APPLICATION_MSWORD("application/msword", "doc"),
+    APPLICATION_DOCX("application/vnd.openxmlformats-officedocument.wordprocessingml.document", "docx"),
+    APPLICATION_EOT("application/vnd.ms-fontobject", "eot"),
+    APPLICATION_EPUB("application/epub+zip", "epub"),
+    APPLICATION_GZIP("application/gzip", "gz"),
+    APPLICATION_GIF("application/gif", "gif"),
+    TEXT_HTML("text/html", "html"),
+    IMAGE_ICON("image/vnd.microsoft.icon", "ico"),
+    TEXT_CALENDAR("text/calendar", "ics"),
+    APPLICATION_JAR("application/java-archive", "jar")
+    ;
+
+    private String mimeType;
+    private String extension;
+
+    public static String isValidMimeType(String mimeType) {
+        for (MimeType type : MimeType.values()) {
+            if (type.getMimeType().equals(mimeType)) {
+                return type.getExtension();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/flow/assignment/config/WebConfig.java
+++ b/src/main/java/flow/assignment/config/WebConfig.java
@@ -1,11 +1,25 @@
 package flow.assignment.config;
 
+import flow.assignment.interceptor.ExtensionHandlerInterceptor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
+@Slf4j
 public class WebConfig implements WebMvcConfigurer {
+
+    private final ExtensionHandlerInterceptor extensionHandlerInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(extensionHandlerInterceptor);
+    }
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")

--- a/src/main/java/flow/assignment/file/repository/ExtensionRepository.java
+++ b/src/main/java/flow/assignment/file/repository/ExtensionRepository.java
@@ -2,9 +2,11 @@ package flow.assignment.file.repository;
 
 import flow.assignment.file.model.entity.Extension;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface ExtensionRepository extends JpaRepository<Extension, Long> {
     Optional<Extension> findByExtension(String extension);
 }

--- a/src/main/java/flow/assignment/interceptor/ExtensionHandlerInterceptor.java
+++ b/src/main/java/flow/assignment/interceptor/ExtensionHandlerInterceptor.java
@@ -1,0 +1,72 @@
+package flow.assignment.interceptor;
+
+import flow.assignment.common.FileSignature;
+import flow.assignment.common.MimeType;
+import flow.assignment.file.model.entity.Extension;
+import flow.assignment.file.repository.ExtensionRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Part;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExtensionHandlerInterceptor implements HandlerInterceptor {
+
+    private final ExtensionRepository extensionRepository;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        Collection<Part> result = request.getParts();
+        for (Part part : result) {
+            String contentType = part.getContentType();
+            String fileName = part.getSubmittedFileName();
+            if (fileSignatureFilter(fileName, part.getInputStream())) {
+                String extension = mimeTypeFilter(contentType);
+                return extensionFilter(extension);
+            } else {
+                return false;
+            }
+        }
+
+        return HandlerInterceptor.super.preHandle(request, response, handler);
+    }
+
+    private Boolean extensionFilter(String extension) {
+        Optional<Extension> extensionInfo = extensionRepository.findByExtension(extension);
+        if (extensionInfo.isPresent()) {
+            if (extensionInfo.get().getStatus()) {
+                return false;
+            } else {
+                return true;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    private String mimeTypeFilter(String mimeType) {
+        return MimeType.isValidMimeType(mimeType);
+    }
+
+    private Boolean fileSignatureFilter(String fileName, InputStream inputStream) throws IOException {
+        String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
+
+        byte[] bytes = inputStream.readAllBytes();
+        String signature = "";
+        for (int i = 0; i < 4; i++) {
+            signature += String.format("%02x", bytes[i]);
+        }
+
+        return FileSignature.isEqualsSignature(extension, signature);
+    }
+}


### PR DESCRIPTION
- 파일 확장자를 필터링할 수 있는 인터셉터 기능을 추가
- HTTP 요청으로 들어오는 파일의 Content-Type을 확인하여 그에 맞는 MimeType을 확장자 값과 매핑할 수 있게 구성
- 파일 시그니처를 분석하여 확장자와 다른 파일 내용을 필터링할 수 있는 기능을 추가