### PR TITLE
[Refactor] 파일 확장자 필터링 기능 개선

### DIFF
--- a/src/main/java/flow/assignment/common/FileSignature.java
+++ b/src/main/java/flow/assignment/common/FileSignature.java
@@ -6,26 +6,27 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum FileSignature {
-    PNG_SIGNATURE("png", "89504e47"),
-    JPG_SIGNATURE("jpg", "ffd8ffe0"),
-    JPEG_SIGNATURE("jpeg", "ffd8ffe0"),
-    BAT_SIGNATURE("bat", "5B332f31"),
-    MP4_SIGNATURE("mp4", "00000018"),
-    IMG_SIGNATURE("img", "00010008"),
-    PPT_SIGNATURE("ppt", "006e1ef0"),
-    DOC_SIGNATURE("doc", "0d444d43"),
-    PDF_SIGNATURE("pdf", "25504446"),
-    GIF_SIGNATURE("gif", "47494638"),
-    MP3_SIGNATURE("mp3", "494433"),
-    JAR_SIGNATURE("jar", "4a415243"),
+    PNG_SIGNATURE("png", "8950"),
+    JPG_SIGNATURE("jpg", "ffd8"),
+    JPEG_SIGNATURE("jpeg", "ffd8"),
+    BAT_SIGNATURE("bat", "5B33"),
+    MP4_SIGNATURE("mp4", "0000"),
+    IMG_SIGNATURE("img", "0001"),
+    PPT_SIGNATURE("ppt", "006e"),
+    DOC_SIGNATURE("doc", "0d44"),
+    PDF_SIGNATURE("pdf", "2550"),
+    GIF_SIGNATURE("gif", "4749"),
+    MP3_SIGNATURE("mp3", "4944"),
+    JAR_SIGNATURE("jar", "4a41"),
     EXE_SIGNATURE("exe", "4d5a"),
-    ZIP_SIGNATURE("zip", "054B0304"),
-    DOCX_SIGNATURE("docx", "504B0304"),
-    TAR_SIGNATURE("tar", "75737461"),
+    ZIP_SIGNATURE("zip", "054B"),
+    DOCX_SIGNATURE("docx", "504B"),
+    TAR_SIGNATURE("tar", "7573"),
+    JS_SIGNATURE("js", "6c65"),
     ;
 
-    private String extension;
-    private String fileSignature;
+    private final String extension;
+    private final String fileSignature;
 
     public static Boolean isEqualsSignature(String extension, String signature) {
         for (FileSignature fileSignature : FileSignature.values()) {

--- a/src/main/java/flow/assignment/common/MimeType.java
+++ b/src/main/java/flow/assignment/common/MimeType.java
@@ -29,11 +29,12 @@ public enum MimeType {
     TEXT_HTML("text/html", "html"),
     IMAGE_ICON("image/vnd.microsoft.icon", "ico"),
     TEXT_CALENDAR("text/calendar", "ics"),
-    APPLICATION_JAR("application/java-archive", "jar")
+    APPLICATION_JAR("application/java-archive", "jar"),
+    TEXT_JAVASCRIPT("text/javascript", "js"),
     ;
 
-    private String mimeType;
-    private String extension;
+    private final String mimeType;
+    private final String extension;
 
     public static String isValidMimeType(String mimeType) {
         for (MimeType type : MimeType.values()) {


### PR DESCRIPTION
- byte 데이터를 16진수의 파일 시그니처로 변환해주는 메서드 구현
- 파일 시그니처 필터링 기능에 예외처리 코드 추가
- MimeType 필터링 기능에 예외처리 코드 추가
- 제한된 확장자에 대한 예외처리 코드 추가
- 테스트 목적으로 enum에 자바스크립트 파일의 시그니처와 MimeType 코드를 추가(추후 변경 예정)