### PR TITLE
[Refactor] 커스텀 확장자를 추가하거나 삭제할 시 중복해서 조회되는 문제를 개선

### DIFF
--- a/src/main/resources/static/js/customExtension.js
+++ b/src/main/resources/static/js/customExtension.js
@@ -1,4 +1,4 @@
-$(function getCustomExtensionList () {
+function loadCustomExtensionList() {
     let option = 'custom'
     const maxCustomExtensionSize = 200
     $.ajax({
@@ -6,8 +6,11 @@ $(function getCustomExtensionList () {
         url: `http://localhost:8080/file/custom/extension/list?option=${option}`,
         success: function (response) {
             if (response.code === 'CUSTOM_002') {
-                let customExtensionList = $('#customExtensionList');
+                let customExtensionList = $('#customExtensionList')
                 let totalCustomExtension = $('#totalCustomExtension')
+                let currentCount = response.result.length;
+                customExtensionList.empty()
+                totalCustomExtension.empty()
 
                 response.result.forEach(function (item, index) {
                     const customExtension = item.extension
@@ -25,7 +28,8 @@ $(function getCustomExtensionList () {
                     });
                     customExtensionList.append(extensionTag)
                 });
-                totalCustomExtension.append(`${response.result.length}/${maxCustomExtensionSize}`)
+
+                totalCustomExtension.append(`${currentCount}/${maxCustomExtensionSize}`)
             }
         },
         error: function (error) {
@@ -36,6 +40,11 @@ $(function getCustomExtensionList () {
             }
         }
     })
+}
+
+$(function getCustomExtensionList () {
+    loadCustomExtensionList()
+    let option = 'custom'
     $('#addCustomExtension').click(function addCustomExtension () {
         let data = $('#extensionInput').val()
         if (data.length <= 20) {
@@ -52,6 +61,7 @@ $(function getCustomExtensionList () {
                     if (response.code === 'CUSTOM_001') {
                         alert(response.message)
                         $('#extensionInput').val('')
+                        loadCustomExtensionList()
                     }
                 },
                 error: function (error) {
@@ -62,7 +72,7 @@ $(function getCustomExtensionList () {
                     } else if (error.code === 'SERVER_ERROR_001') {
                         alert(error.responseJSON.message)
                     }
-                }
+                },
             })
         } else {
             alert('커스텀 확장자의 길이는 최대 20자까지 가능합니다.')
@@ -85,6 +95,7 @@ $(document).on('click', 'button[name="removeExtensionBtn"]', function delCustomE
         success: function (response) {
             if (response.code === 'CUSTOM_003') {
                 alert(response.message)
+                loadCustomExtensionList()
             }
         },
         error: function (error) {

--- a/src/main/resources/templates/form/index.html
+++ b/src/main/resources/templates/form/index.html
@@ -23,8 +23,9 @@
     <input maxlength="20" class="input-extension-style" type="text" placeholder="확장자 입력" id="extensionInput">
     <button class="extension-add-btn" type="button" id="addCustomExtension">+추가</button>
   </div>
-  <div class="custom-extension-box" id="customExtensionList">
+  <div class="custom-extension-box">
     <span class="custom-extension-box-text" id="totalCustomExtension"></span>
+    <div id="customExtensionList"></div>
   </div>
 </div>
 </body>


### PR DESCRIPTION
- 커스텀 확장자를 추가하거나 삭제할 시 기존의 데이터가 남아있어 중복되는 문제를 empty() 메서드를 활용하여 해결
- empty() 메서드를 사용할 때 totalCustomExtension 데이터도 같이 삭제되는 문제가 발생했는데 html 태그를 분리하여 해결