### PR TITLE
[Refactor] mime 타입과 파일 시그니처 필터링 기능을 개선

### DIFF
--- a/src/main/java/flow/assignment/common/filetype/FileSignature.java
+++ b/src/main/java/flow/assignment/common/filetype/FileSignature.java
@@ -1,7 +1,12 @@
-package flow.assignment.common;
+package flow.assignment.common.filetype;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Getter
 @AllArgsConstructor
@@ -22,23 +27,20 @@ public enum FileSignature {
     ZIP_SIGNATURE("zip", "054B"),
     DOCX_SIGNATURE("docx", "504B"),
     TAR_SIGNATURE("tar", "7573"),
-    JS_SIGNATURE("js", "6c65"),
     ;
 
     private final String extension;
     private final String fileSignature;
+    private static final Map<String, FileSignature> SIGNATURE_MAP =
+            Arrays.stream(FileSignature.values())
+                    .collect(Collectors.toMap(FileSignature::getExtension, Function.identity()));
 
     public static Boolean isEqualsSignature(String extension, String signature) {
-        for (FileSignature fileSignature : FileSignature.values()) {
-            if (fileSignature.getExtension().equals(extension)) {
-                if (fileSignature.getFileSignature().equals(signature)) {
-                    return true;
-                } else {
-                    return false;
-                }
-            }
+        String fileSignature = SIGNATURE_MAP.get(extension).getFileSignature();
+        if (fileSignature.equals(signature)) {
+            return true;
+        } else {
+            return false;
         }
-
-        return null;
     }
 }

--- a/src/main/java/flow/assignment/common/filetype/MimeType.java
+++ b/src/main/java/flow/assignment/common/filetype/MimeType.java
@@ -1,7 +1,12 @@
-package flow.assignment.common;
+package flow.assignment.common.filetype;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @AllArgsConstructor
 @Getter
@@ -36,12 +41,16 @@ public enum MimeType {
     private final String mimeType;
     private final String extension;
 
+    public static final Map<String, MimeType> MIME_TYPE_MAP =
+            Arrays.stream(MimeType.values())
+                    .collect(Collectors.toMap(MimeType::getExtension, Function.identity()));
+
     public static String isValidMimeType(String mimeType) {
-        for (MimeType type : MimeType.values()) {
-            if (type.getMimeType().equals(mimeType)) {
-                return type.getExtension();
-            }
+        MimeType resultMimeType = MIME_TYPE_MAP.get(mimeType);
+        if (resultMimeType != null) {
+            return resultMimeType.getExtension();
+        } else {
+            return null;
         }
-        return null;
     }
 }

--- a/src/main/java/flow/assignment/interceptor/ExtensionHandlerInterceptor.java
+++ b/src/main/java/flow/assignment/interceptor/ExtensionHandlerInterceptor.java
@@ -1,7 +1,8 @@
 package flow.assignment.interceptor;
 
-import flow.assignment.common.FileSignature;
-import flow.assignment.common.MimeType;
+import flow.assignment.common.filetype.FileSignature;
+import flow.assignment.common.filetype.GeneralFile;
+import flow.assignment.common.filetype.MimeType;
 import flow.assignment.common.error.ErrorCode;
 import flow.assignment.common.error.exception.InterceptorException;
 import flow.assignment.file.model.entity.Extension;
@@ -73,7 +74,7 @@ public class ExtensionHandlerInterceptor implements HandlerInterceptor {
 
     private Boolean fileSignatureFilter(String extension, String fileSignature) {
         Boolean signature = FileSignature.isEqualsSignature(extension, fileSignature);
-        if (signature == null || !signature) {
+        if (!signature) {
             throw new InterceptorException(ErrorCode.INVALID_FILE_SIGNATURE, "유효하지 않은 파일입니다.");
         } else {
             return true;


### PR DESCRIPTION
- 기존의 enum의 values() 메서드를 사용했던 부분을 Map으로 변경하여 성능을 개선
- 파일 시그니처와 mime 타입의 필터링 기능을 Map에서 가져온 데이터를 비교하는 방식으로 변경